### PR TITLE
Significant Makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ TESTS_OBJECTS = $(TESTS_DIR)/frame_test.o       \
                 $(TESTS_DIR)/test_helper.o      \
                 $(TESTS_DIR)/test_helper_test.o \
 
-.PHONY: test clean
+.PHONY: test clean install uninstall
 
 ttysolitaire: $(SRC_OBJECTS)
 	$(CC) $(CFLAGS) $(SRC) -o $(EXECUTABLE) $(SRC_OBJECTS) $(LDFLAGS)


### PR DESCRIPTION
- [x] Obey `$(DESTDIR)` for packagers
- [x] Use `install` command for more predictable and tuned installation
- [x] General cleanup (e.g., using parens throughout for variables, and adding relevant targets to `.PHONY`)
