### PR TITLE
Makefile: support OS X system ncurses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@ CFLAGS = -W -Wall -pedantic -ansi -std=c99 -g
 
 LDFLAGS = -lncursesw
 
+# OS X installs ncurses with wide character support, but not as "libncurses"
 ifeq ($(shell uname -s),Darwin)
-	LDFLAGS += -L /opt/local/lib
+	LDFLAGS = -lncurses
 endif
 
 PREFIX  = /usr/local


### PR DESCRIPTION
Mac OS X's ncurses includes wide character support, but the library isn't installed under the "ncursesw" name for some reason. It does support everything tty-solitaire needs though, so if the library name is adjusted in LDFLAGS it's possible to use it.

Users who want to use other ncurses libraries (from Macports, Homebrew, etc.) will still be able to do so if they specify LDLAGS in the make invocation.