### PR TITLE
Makefile: remove usage of GNU install-specific flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ clean:
 	@rm -rf {$(SRC_DIR),$(TESTS_DIR)}/*.o $(EXECUTABLE) $(TESTS_EXECUTABLE)
 
 install:
-	@install -Dm755 $(EXECUTABLE) $(DESTDIR)$(PREFIX)/bin/$(EXECUTABLE)
+	@install -d $(DESTDIR)$(PREFIX)/bin
+	@install -m755 $(EXECUTABLE) $(DESTDIR)$(PREFIX)/bin/$(EXECUTABLE)
 
 uninstall:
 	@rm -f $(PREFIX)/bin/$(EXECUTABLE)


### PR DESCRIPTION
The -D flag, though useful, is a GNU extension and isn't compatible with the `install` provided by other OSs. Instead, this adds a separate call to `install -d` to create the target directory before running `install -m755` to install the executable.