### PR TITLE
Fix segfault when launching with unkown option

### DIFF
--- a/src/ttysolitaire.c
+++ b/src/ttysolitaire.c
@@ -22,7 +22,8 @@ int main(int argc, char *argv[]) {
   static const struct option options[] = {
     {"help",    no_argument,       NULL, 'h'},
     {"version", no_argument,       NULL, 'v'},
-    {"passes",  required_argument, NULL, 'p'}
+    {"passes",  required_argument, NULL, 'p'},
+    {0, 0, 0, 0}
   };
 
   program_name = argv[0];


### PR DESCRIPTION
# Bug
When launching with an unkown option, `ttysolitaire` crashes with a segfault.

# Reason
This is due to `getopt_long()` not knowing where to terminate the search for matching options in `options[]`.

# Fix
Append an additional Element to `options[]` containing only zeroes. This is in compliance with the GNU docs. See `man getopt_long` for reference.