### PR TITLE
Fix putting card stacks into invalid state

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -160,7 +160,7 @@ static void handle_card_movement(struct cursor *cursor) {
           erase_cursor(cursor);
           cursor->y--;
         }
-        if (marked_cards_count(*origin) > 0) {
+        if (maneuvre_stack(*origin)) {
           erase_stack(*origin);
           unmark_cards(*origin);
           draw_stack(*origin);


### PR DESCRIPTION
Bug: When the cursor is on a foundation stack or on the wastepile stack,
	it is possible to put this stack into an invalid state by pressing ESC
        while having the stack marked. If this is done on a foundation stack,
        the game cannot be finished anymore.

Reason: unmark_cards() should only be called on maneuvre stacks since it
	alters the y position of cards.

Fix: Only redraw maneuvre stacks on ESC-key action.