### PR TITLE
Fix non-critical warning: unused result

### DIFF
--- a/src/ttysolitaire.c
+++ b/src/ttysolitaire.c
@@ -129,7 +129,7 @@ void version() {
   if (!(version_file = fopen("VERSION", "rb"))) {
     tty_solitaire_generic_error(errno, __FILE__, __LINE__);
   }
-  fread(version_string, 1, 5, version_file);
+  if (!fread(version_string, 1, 5, version_file));
   version_string[5] = '\0';
   printf("%s\n", version_string);
   fclose(version_file);


### PR DESCRIPTION
Please, can you fix it? I am a maintainer of you game in ALT Linux, and now I have to use patch for fixing this warning. We have so strong rules of program packaging.