### PR TITLE
Added ability to use terminal's default background

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -109,7 +109,7 @@ void draw_cursor(struct cursor *cursor) {
 
 void erase_card(struct card *card) {
   werase(card->frame->window);
-  wbkgd(card->frame->window, WHITE_ON_GREEN);
+  wbkgd(card->frame->window, DEFAULT);
   wrefresh(card->frame->window);
 }
 

--- a/src/gui.h
+++ b/src/gui.h
@@ -9,7 +9,7 @@
 #define BLACK_ON_WHITE 1
 #define RED_ON_WHITE   2
 #define WHITE_ON_BLUE  3
-#define WHITE_ON_GREEN 4
+#define DEFAULT 4 // either terminal's default or white on green
 
 extern struct game game;
 

--- a/src/ttysolitaire.c
+++ b/src/ttysolitaire.c
@@ -23,16 +23,18 @@ int main(int argc, char *argv[]) {
   int option;
   int option_index;
   int passes_through_deck = 3;
+  bool default_background = false;
   static const struct option options[] = {
     {"help",    no_argument,       NULL, 'h'},
     {"version", no_argument,       NULL, 'v'},
     {"passes",  required_argument, NULL, 'p'},
+	{"default-backg", no_argument, NULL, 'd'},
     {0, 0, 0, 0}
   };
 
   program_name = argv[0];
 
-  while ((option = getopt_long(argc, argv, "hvp:", options, &option_index)) != -1) {
+  while ((option = getopt_long(argc, argv, "hvp:d", options, &option_index)) != -1) {
     switch (option) {
     case 'v':
       version();
@@ -40,6 +42,9 @@ int main(int argc, char *argv[]) {
     case 'p':
       passes_through_deck = atoi(optarg);
       break;
+	case 'd':
+	  default_background = true;
+	  break;
     case 'h':
     default:
       usage(program_name);
@@ -55,7 +60,16 @@ int main(int argc, char *argv[]) {
   start_color();
   curs_set(FALSE);
   set_escdelay(0);
-  assume_default_colors(COLOR_WHITE, COLOR_GREEN);
+
+  if(default_background) {
+	if( use_default_colors() == ERR ) {
+      assume_default_colors(COLOR_WHITE, COLOR_GREEN);
+	}
+  }
+  else {
+    assume_default_colors(COLOR_WHITE, COLOR_GREEN);
+  }
+
   init_pair(1, COLOR_BLACK, COLOR_WHITE);
   init_pair(2, COLOR_RED, COLOR_WHITE);
   init_pair(3, COLOR_WHITE, COLOR_BLUE);

--- a/src/ttysolitaire.c
+++ b/src/ttysolitaire.c
@@ -61,19 +61,17 @@ int main(int argc, char *argv[]) {
   curs_set(FALSE);
   set_escdelay(0);
 
-  if(default_background) {
-	if( use_default_colors() == ERR ) {
-      assume_default_colors(COLOR_WHITE, COLOR_GREEN);
-	}
+  if(default_background && use_default_colors() == OK) {
+    init_pair(4, -1, -1);
   }
   else {
     assume_default_colors(COLOR_WHITE, COLOR_GREEN);
+    init_pair(4, COLOR_WHITE, COLOR_GREEN);
   }
 
   init_pair(1, COLOR_BLACK, COLOR_WHITE);
   init_pair(2, COLOR_RED, COLOR_WHITE);
   init_pair(3, COLOR_WHITE, COLOR_BLUE);
-  init_pair(4, COLOR_WHITE, COLOR_GREEN);
 
   int key;
 

--- a/src/ttysolitaire.c
+++ b/src/ttysolitaire.c
@@ -28,7 +28,7 @@ int main(int argc, char *argv[]) {
     {"help",    no_argument,       NULL, 'h'},
     {"version", no_argument,       NULL, 'v'},
     {"passes",  required_argument, NULL, 'p'},
-	{"default-backg", no_argument, NULL, 'd'},
+    {"default-backg", no_argument, NULL, 'd'},
     {0, 0, 0, 0}
   };
 

--- a/src/ttysolitaire.c
+++ b/src/ttysolitaire.c
@@ -134,10 +134,11 @@ void draw_greeting() {
 }
 
 void usage(const char *program_name) {
-  printf("usage: %s [-v|--version] [-h|--help] [-p|--passes=NUMBER]\n", program_name);
-  printf("  -v, --version  Show version\n");
-  printf("  -h, --help     Show this message\n");
-  printf("  -p, --passes   Number of passes through the deck\n");
+  printf("usage: %s [-v|--version] [-h|--help] [-p|--passes=NUMBER] [-d|--default-backg]\n", program_name);
+  printf("  -v, --version       Show version\n");
+  printf("  -h, --help          Show this message\n");
+  printf("  -p, --passes        Number of passes through the deck\n");
+  printf("  -d, --default-backg Use default terminal background color\n");
 }
 
 void version() {


### PR DESCRIPTION
This is useful when someone uses semi-transparent terminal for looks. I made it optional