### PR TITLE
Add C flag to allow tentative definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION = 1.1.1
 
 CC     ?= gcc
 CFLAGS ?= -g
-CFLAGS += -W -Wall -pedantic -ansi -std=c99 -DVERSION=\"$(VERSION)\"
+CFLAGS += -W -Wall -pedantic -ansi -std=c99 -DVERSION=\"$(VERSION)\" -fcommon
 
 # OS X installs ncurses with wide character support, but not as "libncurses".
 ifeq ($(shell uname -s),Darwin)


### PR DESCRIPTION
[GCC 10](https://gcc.gnu.org/gcc-10/changes.html) changes default C compilation behaviour. In particular:
> GCC now defaults to -fno-common. As a result, global variable accesses are more efficient on various targets. In C, global variables with multiple tentative definitions now result in linker errors. With -fcommon such definitions are silently merged during linking. 

Adding -fcommon to CFLAGS in the Makefile fixes #40.
I wonder whether some minor refactoring would be a better solution, but I doubt any performance benefits would be worth the effort.