### PR TITLE
Added wraparound navigation

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -44,6 +44,12 @@ void cursor_move(struct cursor *cursor, enum movement movement) {
         cursor_move(cursor, UP);
         cursor_move(cursor, DOWN);
       }
+    } else {
+      cursor->x = CURSOR_MANEUVRE_6_X;
+      if (cursor->y > CURSOR_BEGIN_Y) {
+        cursor_move(cursor, UP);
+        cursor_move(cursor, DOWN);
+      }
     }
     break;
   case DOWN:
@@ -76,6 +82,12 @@ void cursor_move(struct cursor *cursor, enum movement movement) {
   case RIGHT:
     if (cursor->x < 49) {
       cursor->x = cursor->x + 8;
+      if (cursor->y > CURSOR_BEGIN_Y) {
+        cursor_move(cursor, UP);
+        cursor_move(cursor, DOWN);
+      }
+    } else {
+      cursor->x = CURSOR_BEGIN_X;
       if (cursor->y > CURSOR_BEGIN_Y) {
         cursor_move(cursor, UP);
         cursor_move(cursor, DOWN);


### PR DESCRIPTION
Add feature that lets you press left button at left-most stack to loop cursor around to right-most stack (and vice-versa). Related to Issue #50. I find it helpful personally when I play. 

First pull request so welcome any feedback. 