### PR TITLE
Make gcc10 happy

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -8,6 +8,8 @@
 #include "game.h"
 #include "common.h"
 
+struct cursor *cursor;
+
 void cursor_malloc(struct cursor **cursor) {
   if (!(*cursor = malloc(sizeof(**cursor)))) {
     tty_solitaire_generic_error(errno, __FILE__, __LINE__);

--- a/src/deck.c
+++ b/src/deck.c
@@ -5,6 +5,8 @@
 #include "deck.h"
 #include "common.h"
 
+struct deck *deck;
+
 void deck_malloc(struct deck **deck) {
   if (!(*deck = malloc(sizeof(**deck)))) {
     tty_solitaire_generic_error(errno, __FILE__, __LINE__);

--- a/src/game.h
+++ b/src/game.h
@@ -35,8 +35,8 @@ struct game {
   int four_color_deck;
 };
 
-struct deck *deck;
-struct cursor *cursor;
+extern struct deck *deck;
+extern struct cursor *cursor;
 
 bool maneuvre_stack(struct stack *);
 bool stock_stack(struct stack *);


### PR DESCRIPTION
gcc-10 and above flipped a default from -fcommon to -fno-common.
So now GCC will reject multiple definitions of global variables.