### PR TITLE
change the usage output to not include the full contents of argv[0]

### DIFF
--- a/src/ttysolitaire.c
+++ b/src/ttysolitaire.c
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <getopt.h>
+#include <libgen.h>
 #include <locale.h>
 #include <ncurses.h>
 #include <stdlib.h>
@@ -33,7 +34,7 @@ int main(int argc, char *argv[]) {
       {"no-background-color", no_argument, &no_background_color, 1},
       {0, 0, 0, 0}};
 
-  program_name = argv[0];
+  program_name = basename(argv[0]);
 
   while ((option = getopt_long(argc, argv, "hvp:", options, &option_index)) !=
          -1) {


### PR DESCRIPTION
## Now

$ /tmp/tty-solitaire/ttysolitaire --help

usage: /**tmp**/**tty-solitaire**/ttysolitaire [OPTIONS]
  -v, --version              Show version
  -h, --help                 Show this message
  -p, --passes               Number of passes through the deck  (default: 3)
      --four-color-deck      Draw unique card suit colors       (default: false)
      --no-background-color  Don't draw background color        (default: false)


## After

$ /tmp/tty-solitaire/ttysolitaire --help

usage: **ttysolitaire** [OPTIONS]
  -v, --version              Show version
  -h, --help                 Show this message
  -p, --passes               Number of passes through the deck  (default: 3)
      --four-color-deck      Draw unique card suit colors       (default: false)
      --no-background-color  Don't draw background color        (default: false)


## More Information

 https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=993279