### PR TITLE
src/gui.c: always use "%s"-style format for printf()-style functions

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -13,9 +13,9 @@ static const char *card_values[13] = {"A", "2", "3",  "4", "5", "6", "7",
                                       "8", "9", "10", "J", "Q", "K"};
 
 static void draw_value(struct card *card) {
-  mvwprintw(card->frame->window, 0, 0, card_values[card->value]);
+  mvwprintw(card->frame->window, 0, 0, "%s", card_values[card->value]);
   mvwprintw(card->frame->window, 4, 7 - strlen(card_values[card->value]),
-            card_values[card->value]);
+            "%s", card_values[card->value]);
 }
 
 static void draw_suit(struct card *card) {
@@ -43,9 +43,9 @@ static void draw_suit(struct card *card) {
     }
   }
   mvwprintw(card->frame->window, 0, strlen(card_values[card->value]),
-            card_suits[card->suit]);
+            "%s", card_suits[card->suit]);
   mvwprintw(card->frame->window, 4, 6 - strlen(card_values[card->value]),
-            card_suits[card->suit]);
+            "%s", card_suits[card->suit]);
   if (card->suit % 2 == 0) {
     wattroff(card->frame->window, COLOR_PAIR(RED_ON_WHITE));
   } else {


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    src/gui.c:48:13: error: format not a string literal and no format arguments [-Werror=format-security]
       48 |             card_suits[card->suit]);
          |             ^~~~~~~~~~

Let's wrap all the missing places with "%s" format.