### PR TITLE
Automatically expose the top card on a maneuver after a move

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -141,7 +141,16 @@ void move_block(struct stack **origin, struct stack **destination,
   if (stack_length(*destination) > 1) {
     cursor->y += block_size;
   }
-  stack_free(tmp);
+}
+
+void expose_top(struct stack **origin)
+{
+  struct card *top;
+  if((top = stack_pop(origin)))
+  {
+    card_expose(top);
+    stack_push(origin, top);
+  }
 }
 
 static void fill_deck(struct deck *deck) {

--- a/src/game.h
+++ b/src/game.h
@@ -43,6 +43,7 @@ bool stock_stack(struct stack *);
 bool valid_move(struct stack *, struct stack *);
 void move_card(struct stack **, struct stack **);
 void move_block(struct stack **, struct stack **, int);
+void expose_top(struct stack **);
 void game_init(struct game *, int, int);
 bool game_won();
 void game_end();

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -157,6 +157,7 @@ static void handle_card_movement(struct cursor *cursor) {
               ;
             if (valid_move(block, *destination)) {
               move_block(origin, destination, _marked_cards_count);
+              expose_top(origin);
             }
           } else {
             if (valid_move(*origin, *destination)) {
@@ -164,6 +165,7 @@ static void handle_card_movement(struct cursor *cursor) {
                 cursor->y++;
               }
               move_card(origin, destination);
+              expose_top(origin);
             }
           }
           draw_stack(*origin);


### PR DESCRIPTION
I made it so that after you move a card from a maneuver from somewhere else, it exposes the top card on the original maneuver automatically. Manually doing this after almost each move was annoying to me.