### PR TITLE
Memory gets freed when you quit after you select a card

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -66,6 +66,7 @@ static void handle_card_movement(struct cursor *cursor) {
   for (;;) {
     if ((key = getch()) == 'q' || key == 'Q') {
       endwin();
+      game_end();
       exit(0);
     }
     if (term_size_ok()) {


### PR DESCRIPTION
In the handle_card_movement() function, if you press the 'q' key, the game_end() function was not being called, causing memory leaks. 