### PR TITLE
Fix drawing bug on maneuvre stacks

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -50,25 +50,25 @@ void cursor_move(struct cursor *cursor, enum movement movement) {
     if (cursor->y == CURSOR_BEGIN_Y) {
       switch (cursor->x - 3) {
       case MANEUVRE_0_BEGIN_X:
-        cursor->y = cursor->y + 7 + stack_length(deck->maneuvre[0]);
+        cursor->y = 6 + deck->maneuvre[0]->card->frame->begin_y;
         break;
       case MANEUVRE_1_BEGIN_X:
-        cursor->y = cursor->y + 7 + stack_length(deck->maneuvre[1]);
+        cursor->y = 6 + deck->maneuvre[1]->card->frame->begin_y;
         break;
       case MANEUVRE_2_BEGIN_X:
-        cursor->y = cursor->y + 7 + stack_length(deck->maneuvre[2]);
+        cursor->y = 6 + deck->maneuvre[2]->card->frame->begin_y;
         break;
       case MANEUVRE_3_BEGIN_X:
-        cursor->y = cursor->y + 7 + stack_length(deck->maneuvre[3]);
+        cursor->y = 6 + deck->maneuvre[3]->card->frame->begin_y;
         break;
       case MANEUVRE_4_BEGIN_X:
-        cursor->y = cursor->y + 7 + stack_length(deck->maneuvre[4]);
+        cursor->y = 6 + deck->maneuvre[4]->card->frame->begin_y;
         break;
       case MANEUVRE_5_BEGIN_X:
-        cursor->y = cursor->y + 7 + stack_length(deck->maneuvre[5]);
+        cursor->y = 6 + deck->maneuvre[5]->card->frame->begin_y;
         break;
       case MANEUVRE_6_BEGIN_X:
-        cursor->y = cursor->y + 7 + stack_length(deck->maneuvre[6]);
+        cursor->y = 6 + deck->maneuvre[6]->card->frame->begin_y;
         break;
       }
     }


### PR DESCRIPTION
Instead of using stack_length, base the cursor Y position on the location of the first card in the stack.

To reproduce:
[space] to start game
[down] to move to first maneuvre stack
[space] to select card
[up] move up
[down] move back down to selected card. Cursor is one line too high [space] deselect card
[space] select card.

The bottom center of the card is drawn with the background color.