### PR TITLE
Auto-move a card to foundation pile when unselected

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -56,7 +56,7 @@ static int maneuvre_begin_x(int x) {
   }
 }
 
-static bool waste_pile_stack(struct stack *stack) {
+bool waste_pile_stack(struct stack *stack) {
   return ((stack->card->frame->begin_y == WASTE_PILE_BEGIN_Y) &&
           (stack->card->frame->begin_x == WASTE_PILE_BEGIN_X));
 }

--- a/src/game.h
+++ b/src/game.h
@@ -38,6 +38,7 @@ struct game {
 extern struct deck *deck;
 extern struct cursor *cursor;
 
+bool waste_pile_stack(struct stack *);
 bool maneuvre_stack(struct stack *);
 bool stock_stack(struct stack *);
 bool valid_move(struct stack *, struct stack *);

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -167,6 +167,19 @@ static void handle_card_movement(struct cursor *cursor) {
               move_card(origin, destination);
             }
           }
+
+          /* If they only had one card selected... */
+          if (*origin == *destination && ((maneuvre_stack(*origin)  && _marked_cards_count == 1) || waste_pile_stack(*origin))) {
+            /* see if we can automatically move card to foundation */
+            for (int i = 0; i <= 3; ++i) {
+              destination = (&(deck->foundation[i]));
+              if (valid_move(*origin, *destination)) {
+                move_card(origin, destination);
+                break;
+              }
+            }
+          }
+
           draw_stack(*origin);
           draw_stack(*destination);
           if (maneuvre_stack(*origin) && *origin == *destination) {


### PR DESCRIPTION
Automatically moves a selected card to the appropriate foundation pile when you unselect, if it would be a valid move. This allows you to "double-tap" space on an Ace to send it to the foundation pile (for example).