### PR TITLE
Make Makefile ncurses flags handling in Makefile more flexible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,11 @@ CFLAGS += -W -Wall -pedantic -ansi -std=c99 -DVERSION=\"$(VERSION)\"
 # The Ncurses library with wide character support is available as "lncurses"
 # under macOS.
 ifeq ($(shell uname -s),Darwin)
-	LDFLAGS += -lncurses
+	NCURSES_LDFLAGS ?= -lncurses
 else
-	LDFLAGS += -lncursesw
+	NCURSES_LDFLAGS ?= -lncursesw
 endif
+LDFLAGS += $(NCURSES_LDFLAGS)
 
 PREFIX ?= /usr/local
 


### PR DESCRIPTION
Allow ncurses LDFLAGS to be provided externally, e.g. by package build system, which may use different system pecific values such as `-lncurses -ltinfo` on FreeBSD.