### PR TITLE
Fix function prototypes

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -5,7 +5,7 @@
 
 #include "common.h"
 
-bool term_size_ok() {
+bool term_size_ok(void) {
   int lines, columns;
   getmaxyx(stdscr, lines, columns);
   return(lines >= MIN_TERM_LINES && columns >= MIN_TERM_COLS);

--- a/src/common.h
+++ b/src/common.h
@@ -12,6 +12,6 @@
 extern const char *program_name;
 
 void tty_solitaire_generic_error(int, char *, int);
-bool term_size_ok();
+bool term_size_ok(void);
 
 #endif

--- a/src/game.c
+++ b/src/game.c
@@ -222,12 +222,12 @@ void game_init(struct game *game, int passes_through_deck,
   game->passes_through_deck_left = passes_through_deck;
 }
 
-void game_end() {
+void game_end(void) {
   cursor_free(cursor);
   deck_free(deck);
 }
 
-bool game_won() {
+bool game_won(void) {
   // If any card in the maneuvre stacks is covered, game is not won.
   for (int i = 0; i < MANEUVRE_STACKS_NUMBER; i++) {
     for (struct stack *j = deck->maneuvre[i]; j != NULL; j = j->next) {

--- a/src/game.h
+++ b/src/game.h
@@ -45,7 +45,7 @@ bool valid_move(struct stack *, struct stack *);
 void move_card(struct stack **, struct stack **);
 void move_block(struct stack **, struct stack **, int);
 void game_init(struct game *, int, int);
-bool game_won();
-void game_end();
+bool game_won(void);
+void game_end(void);
 
 #endif

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -10,7 +10,7 @@
 #include "gui.h"
 #include "common.h"
 
-static void handle_term_resize() {
+static void handle_term_resize(void) {
   clear();
   refresh();
   if (term_size_ok()) {

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -11,6 +11,6 @@ extern struct deck *deck;
 extern struct cursor *cursor;
 extern struct game game;
 
-void keyboard_event();
+void keyboard_event(int key);
 
 #endif

--- a/src/ttysolitaire.c
+++ b/src/ttysolitaire.c
@@ -16,9 +16,9 @@
 const char *program_name;
 struct game game;
 
-void version();
+void version(void);
 void usage(const char *);
-void draw_greeting();
+void draw_greeting(void);
 
 int main(int argc, char *argv[]) {
   int option;
@@ -129,7 +129,7 @@ int main(int argc, char *argv[]) {
   return (0);
 }
 
-void draw_greeting() {
+void draw_greeting(void) {
   mvprintw(8, 26, "Welcome to tty-solitaire.");
   mvprintw(10, 21, "Move with the arrow keys or <hjkl>.");
   mvprintw(12, 18, "Use the space bar to select and place cards.");
@@ -150,4 +150,4 @@ void usage(const char *program_name) {
          "(default: false)\n");
 }
 
-void version() { printf("%s\n", VERSION); }
+void version(void) { printf("%s\n", VERSION); }


### PR DESCRIPTION
- Use `void` for functions which take no arguments, as per C standard. This also fixes warnings with clang 18
- Fix prototype of `keyboard_event` which misses an argument