### PR TITLE
Implement GitHub actions based CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+on: [ push, pull_request ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.may_fail }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { cc: gcc, may_fail: false }
+          - { cc: clang, may_fail: false }
+          - { cc: gcc, cflags: -Werror, may_fail: true }
+          - { cc: clang, cflags: -Werror, may_fail: true }
+    name: ${{ matrix.cc }} ${{ matrix.cflags }}
+    env:
+      CC: ${{ matrix.cc }}
+      CFLAGS: ${{ matrix.cflags }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: make
+      - name: Test
+        run: make test
+      - name: Install
+        env:
+          DESTDIR: /
+        run: sudo make install
+      - name: Uninstall
+        run: sudo make uninstall


### PR DESCRIPTION
As discussed in https://github.com/mpereira/tty-solitaire/pull/71#issuecomment-2816716559
Example run: https://github.com/AMDmi3/tty-solitaire/actions/runs/14576513197
Contains gcc/clang builds (to catch more potential problems) + `-Werror` variants which current both fail due to different reasons but are set not to fail the whole build.